### PR TITLE
content: 1.1.71: Native assets

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -4,7 +4,7 @@ const config = generateDeploymentConfig("plh_kids_teens_my");
 
 config.git = {
   content_repo: "https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-my-content.git",
-  content_tag_latest: "1.1.70",
+  content_tag_latest: "1.1.71",
 };
 
 
@@ -26,10 +26,8 @@ config.google_drive.assets_folders = [
 config.android = {
   app_id:'international.idems.plh_kids_teens_my',
   app_name:'Naungan Kasih',
-  splash_asset_path: "./app_data/assets/android/splash.png",
-  icon_asset_path: "./app_data/assets/android/icon.png",
-  icon_asset_foreground_path: "./app_data/assets/android/icon-foreground.png",
-  icon_asset_background_path: "./app_data/assets/android/icon-background.png",
+  logo_asset_path: "./app_data/assets/android/icon-foreground.png",
+  logo_background_color: "#FFFFFF",
   zoom_enabled: true
 };
 
@@ -37,7 +35,7 @@ config.ios = {
   app_id:"international.idems.plh_kids_teens_my",
   app_name:"Naungan Kasih",
   logo_asset_path: "./app_data/assets/android/icon-foreground.png",
-  logo_background_color: "#0E3A5A",
+  logo_background_color: "#FFFFFF",
   zoom_enabled: true
 };
 


### PR DESCRIPTION
Updates the config for Android and iOS to generate an up-to-date app icon from [this logo](https://drive.google.com/file/d/1uJRifeYfScvqXTYKaKbFMG4RdhKRrTdp/view?usp=sharing) with a white background:

<img width="520" height="1024" alt="AppIcon-512@2x" src="https://github.com/user-attachments/assets/03498982-5750-44b8-9ba3-697b0bd5391b" />
